### PR TITLE
Fix missing Plotly script

### DIFF
--- a/polar_manager.html
+++ b/polar_manager.html
@@ -29,11 +29,8 @@
   <div class="chart-container"><div id="polarChart" style="width:100%;height:400px;"></div></div>
   <div class="chart-container"><div id="vmgChart"   style="width:100%;height:400px;"></div></div>
 
-  <!-- INLINE PLOTLY.JS v2.26.4 (minified) -->
-  <script>
-  /*! For license information please see plotly.min.js.LICENSE.txt */
-  /* Paste the entire contents of plotly.min.js v2.26.4 here */
-  </script>
+  <!-- Load Plotly.js -->
+  <script src="https://cdn.plot.ly/plotly-2.26.4.min.js"></script>
 
   <script>
     if (typeof Plotly === 'undefined') {


### PR DESCRIPTION
## Summary
- load Plotly from CDN instead of empty placeholder script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b4cde11483299673875f12e4139a