### PR TITLE
Limit polar diagram to 180° sector

### DIFF
--- a/polar_manager.html
+++ b/polar_manager.html
@@ -26,7 +26,7 @@
   </div>
   <div id="errorMessage" class="error" style="display:none;"></div>
   <table id="dataTable"></table>
-  <div class="chart-container"><div id="polarChart" style="width:100%;height:600px;"></div></div>
+  <div class="chart-container"><div id="polarChart" style="width:100%;height:800px;"></div></div>
   <div class="chart-container"><div id="vmgChart"   style="width:100%;height:400px;"></div></div>
 
   <!-- Load Plotly.js -->

--- a/polar_manager.html
+++ b/polar_manager.html
@@ -26,7 +26,7 @@
   </div>
   <div id="errorMessage" class="error" style="display:none;"></div>
   <table id="dataTable"></table>
-  <div class="chart-container"><div id="polarChart" style="width:100%;height:400px;"></div></div>
+  <div class="chart-container"><div id="polarChart" style="width:100%;height:600px;"></div></div>
   <div class="chart-container"><div id="vmgChart"   style="width:100%;height:400px;"></div></div>
 
   <!-- Load Plotly.js -->

--- a/polar_manager.js
+++ b/polar_manager.js
@@ -108,6 +108,8 @@ function plotPolar() {
     polarData.forEach(rw=>{ if(rw[w]!=null){ theta.push(rw.angle); r.push(rw[w]); vmax=Math.max(vmax,rw[w]); } });
     return {type:'scatterpolar',theta,r,mode:'lines+markers',name:`${w}`,marker:{size:6}};
   });
+  // Show polar data as a right-hand semicircle with 0° at the top
+  // and angles increasing clockwise (0°→top, 90°→right, 180°→bottom)
   Plotly.newPlot('polarChart', traces, {
     polar:{
       angularaxis:{ rotation:90, direction:'clockwise', range:[0,180] },

--- a/polar_manager.js
+++ b/polar_manager.js
@@ -114,7 +114,7 @@ function plotPolar() {
     polar:{
       angularaxis:{ rotation:90, direction:'clockwise', range:[0,180] },
       radialaxis:{ range:[0,vmax*1.1] },
-      sector:[0,180]
+      sector:[-90,90]
     },
     showlegend:true
   });

--- a/polar_manager.js
+++ b/polar_manager.js
@@ -109,7 +109,11 @@ function plotPolar() {
     return {type:'scatterpolar',theta,r,mode:'lines+markers',name:`${w}`,marker:{size:6}};
   });
   Plotly.newPlot('polarChart', traces, {
-    polar:{ angularaxis:{ rotation:90, direction:'clockwise', range:[0,180] }, radialaxis:{ range:[0,vmax*1.1] } },
+    polar:{
+      angularaxis:{ rotation:90, direction:'clockwise', range:[0,180] },
+      radialaxis:{ range:[0,vmax*1.1] },
+      sector:[0,180]
+    },
     showlegend:true
   });
 }

--- a/polar_manager.js
+++ b/polar_manager.js
@@ -108,8 +108,8 @@ function plotPolar() {
     polarData.forEach(rw=>{ if(rw[w]!=null){ theta.push(rw.angle); r.push(rw[w]); vmax=Math.max(vmax,rw[w]); } });
     return {type:'scatterpolar',theta,r,mode:'lines+markers',name:`${w}`,marker:{size:6}};
   });
-  // Show polar data as a right-hand semicircle with 0° at the top
-  // and angles increasing clockwise (0°→top, 90°→right, 180°→bottom)
+  // Display a semicircle rotated 90° counter-clockwise from the previous view so
+  // 0° is at the top, 90° to the right and 180° at the bottom
   Plotly.newPlot('polarChart', traces, {
     polar:{
       angularaxis:{ rotation:90, direction:'clockwise', range:[0,180] },


### PR DESCRIPTION
## Summary
- restrict polar diagram display to half circle
- enlarge polar chart for easier reading

## Testing
- `node -c polar_manager.js`

------
https://chatgpt.com/codex/tasks/task_e_6840b97423988329890d03a10b296afb