### PR TITLE
Improve layout with flex container

### DIFF
--- a/polar_manager.html
+++ b/polar_manager.html
@@ -5,12 +5,13 @@
   <title>Polar Diagram Manager</title>
   <style>
     body { font-family: sans-serif; margin: 20px; }
-    table { border-collapse: collapse; margin-bottom: 20px; }
+    table { border-collapse: collapse; margin-bottom: 20px; margin-right:20px; }
     th, td { border: 1px solid #ccc; padding: 4px 8px; text-align: center; }
     th { background: #f0f0f0; }
     input { width: 60px; }
     button, input[type=file] { margin-right: 8px; margin-bottom: 12px; }
     .chart-container { margin-bottom: 30px; }
+    .layout { display:flex; align-items:flex-start; }
     .error { color: red; margin-bottom: 20px; }
   </style>
 </head>
@@ -25,8 +26,10 @@
     <input type="file" id="importFile" accept="application/json">
   </div>
   <div id="errorMessage" class="error" style="display:none;"></div>
-  <table id="dataTable"></table>
-  <div class="chart-container"><div id="polarChart" style="width:100%;height:800px;"></div></div>
+  <div class="layout">
+    <table id="dataTable"></table>
+    <div class="chart-container"><div id="polarChart" style="width:100%;height:800px;"></div></div>
+  </div>
   <div class="chart-container"><div id="vmgChart"   style="width:100%;height:400px;"></div></div>
 
   <!-- Load Plotly.js -->


### PR DESCRIPTION
## Summary
- use a flex layout so the table and polar chart sit side by side

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c2585ce483298690e20b9cb5cc65